### PR TITLE
Add master branch build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/equinor/flownet/CI)
 [![Python 3.6 | 3.7](https://img.shields.io/badge/python-3.6%20|%203.7-blue.svg)](https://www.python.org/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/equinor/flownet.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/equinor/flownet/alerts/)


### PR DESCRIPTION
The build of FlowNet is currently failing - but there was no badge to actually show that the master branch failed to build. This PR puts back the badge - but now from github actions.